### PR TITLE
Select favorite languages after signup

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -10,7 +10,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
                          I18n.t "devise.omniauth_callbacks.bad_email_success", kind: "GitHub"
                        end
 
-      sign_in_and_redirect @user, event: :authentication
+      redirect_authenticated_user(@user)
     else
       session["devise.github_data"] = request.env["omniauth.auth"].delete("extra")
       flash[:error]  = no_email_error if request.env["omniauth.auth"].info.email.blank?
@@ -21,6 +21,15 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   private
+
+  def redirect_authenticated_user(authenticated_user)
+    if authenticated_user.should_select_languages?
+      sign_in authenticated_user
+      redirect_to user_languages_path(authenticated_user), event: :authentication
+    else
+      sign_in_and_redirect authenticated_user, event: :authentication
+    end
+  end
 
   def no_email_error
     msg =  "You need a public email address on GitHub to sign up you can add"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -49,6 +49,10 @@ class UsersController < ApplicationController
     redirect_to root_url, notice: "Successfully removed your user account"
   end
 
+  def languages
+    @user = current_user
+  end
+
   private
 
   def user_params

--- a/app/views/users/_all_languages.html.slim
+++ b/app/views/users/_all_languages.html.slim
@@ -1,0 +1,9 @@
+section.user-favorite-langs.content-section
+    h2.content-section-title Select your favorite languages:
+    = form_for user do |f|
+      ul.all-languages-list
+        - Repo.all_languages.each do |language|
+          li.language-item
+            = f.check_box :favorite_languages, { multiple: true }, language, nil
+            = f.label language, for: "user_favorite_languages_#{language.downcase}"
+      p= button_tag "Save Favorite Languages", class: "button full-width-action"

--- a/app/views/users/languages.html.slim
+++ b/app/views/users/languages.html.slim
@@ -1,0 +1,3 @@
+.subpage-content-wrapper
+  == render 'users/all_languages', user: @user
+  

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -52,12 +52,4 @@
           .slats-action
             p= @user.skip_issues_with_pr
 
-    section.user-favorite-langs.content-section
-      h2.content-section-title Select your favorite languages:
-      = form_for @user do |f|
-        ul.all-languages-list
-          - Repo.all_languages.each do |language|
-            li.language-item
-              = f.check_box :favorite_languages, { multiple: true }, language, nil
-              = f.label language, for: "user_favorite_languages_#{language.downcase}"
-        p= button_tag "Save Favorite Languages", class: "button full-width-action"
+    == render 'users/all_languages', user: @user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,10 @@ CodeTriage::Application.routes.draw do
     resources :after_signup, only: [:show, :update]
   end
 
-  resources   :users, only: [:show, :edit, :update, :destroy]
+  resources :users, only: [:show, :edit, :update, :destroy] do
+    get :languages
+  end
+
   get         "/users/unsubscribe/:account_delete_token" => "users#token_delete", as: :token_delete_user
   delete      "/users/unsubscribe/:account_delete_token" => "users#token_destroy"
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -108,6 +108,27 @@ class UserTest < ActiveSupport::TestCase
     assert_not u.has_favorite_languages?
   end
 
+  test "user created less than 2 days ago should select favorite languages" do
+    created_at = 1.hour.ago
+    u = User.new(favorite_languages: [], created_at: created_at)
+
+    assert u.should_select_languages?
+  end
+
+  test "user created more than 2 days ago shouldn't select favorite languages" do
+    created_at = 3.days.ago
+    u = User.new(favorite_languages: [], created_at: created_at)
+
+    assert_not u.should_select_languages?
+  end
+
+  test "user created less than 2 days ago who already select languages shouldn't have to select again" do
+    created_at = 1.days.ago
+    u = User.new(favorite_languages: ['ruby'], created_at: created_at)
+
+    assert_not u.should_select_languages?
+  end
+
   test "account_delete_token should be created on first use" do
     u = User.new
     assert_nil u[:account_delete_token]


### PR DESCRIPTION


## Description
When a new user signs up, they are redirected to a page where they can select their favorite languages.

They'll be redirected unless:

- They were created more than two days ago.
- They already selected a language.

## Related Issue
https://github.com/codetriage/codetriage/issues/788

## Motivation and Context
This is a continuation of https://github.com/codetriage/codetriage/issues/701. We'll use this information to poke inactive users more effectively.

## How Has This Been Tested?

I added new tests to the `omniauth_callback_controller` to ensure that the user will be redirected correctly. Some unit tests for the `should_select_languages?` methods were also added.

## Screenshots (if appropriate):

![Screen Shot 2019-07-04 at 18 56 25](https://user-images.githubusercontent.com/5025816/60688744-790d4180-9e8d-11e9-8652-e59e9f723c10.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
